### PR TITLE
host scripts on GitHub Pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,0 @@
-.PHONY: push-install-cog
-push-install-cog:
-	gsutil cp scripts/install-cog.sh gs://replicate-public/codespaces/install-cog.sh

--- a/README.md
+++ b/README.md
@@ -5,5 +5,5 @@
 Run the following to install Cog and nvidia-docker:
 
 ```
-curl https://storage.googleapis.com/replicate-public/codespaces/install-cog.sh | bash
+curl https://replicate.github.io/codespaces/scripts/install-cog.sh | bash
 ```


### PR DESCRIPTION
This PR changes the installation script to use GitHub Pages instead of Google Cloud Storage. With this change, the hosted scripts will automatically been in sync with the main branch without any human intervention or credentials required.

cc @andreasjansson @chenxwh 