### PR TITLE
handle case where docker.pid doesn't exist

### DIFF
--- a/scripts/install-cog.sh
+++ b/scripts/install-cog.sh
@@ -23,6 +23,6 @@ sudo dpkg  --ignore-depends=docker-ce -i *.deb
 popd
 
 # restart docker
-sudo rm /var/run/docker.pid
+sudo rm -f /var/run/docker.pid
 sudo killall -9 dockerd
 sudo bash -c "nohup dockerd &>/var/log/dockerd.log &"


### PR DESCRIPTION
Once upon a time, GitHub changed something in the Codespaces env and we had to update our script to `rm docker.pid`. (See https://github.com/replicate/codespaces/pull/5)

Today, it seems that the env has changed again, and `docker.pid` is no longer around. This PR updates the script to delete the file if it exists, but not blow up if the file doesn't exist.